### PR TITLE
Corrected inconsistent return count in point_utils.project() function

### DIFF
--- a/utils/point_utils.py
+++ b/utils/point_utils.py
@@ -78,5 +78,5 @@ def project(point3d: np.ndarray, T_w2c: np.ndarray, calibK: np.ndarray, frame_h:
         return u_proj[mask > 0], v_proj[mask > 0], z[mask > 0], mask
     else:
         if u_proj < 0 or u_proj >= frame_w -1 or v_proj < 0 or v_proj >= frame_h - 1 and z > 0: 
-            return None, None, None
-        return u_proj, v_proj, z
+            return None, None, None, None
+        return u_proj, v_proj, z, None


### PR DESCRIPTION
The multi-point branch in project() returned four values (u, v, z, mask), while the
single-point branch returned only three, causing a ValueError when training with RGB+SLAM. This commit aligns the return signature, using None as a placeholder for the mask.