### PR TITLE
 Consistent return signature in aria_utils.project() to prevent unpacking errors

### DIFF
--- a/scripts/aria_utils.py
+++ b/scripts/aria_utils.py
@@ -171,8 +171,8 @@ def project(
             or v_proj >= frame_h - 1
             and z > 0
         ):
-            return None, None, None
-        return u_proj, v_proj, z
+            return None, None, None, np.array([False])
+        return u_proj, v_proj, z, np.array([True])
 
 
 def read_frames_from_metadata(transforms_json: str = "transforms.json"):

--- a/scripts/extract_aria_vrs.py
+++ b/scripts/extract_aria_vrs.py
@@ -968,7 +968,7 @@ def create_visible_depth_map(
         for uid in uids:
             pt3d = points3d[uid].position_world
 
-            u, v, z = project(pt3d[:, None], w2c, calibK, frame_h, frame_w)
+            u, v, z, _ = project(pt3d[:, None], w2c, calibK, frame_h, frame_w)
 
             if u is not None:
                 frame_pts3d["u"].append(u[0])


### PR DESCRIPTION
This PR fixes value error unpacking exceptions of the aria_utils.project() function, which previously had an inconsistent return signature, returning four values for points3d inputs with shape > 1, and only three otherwise.

The project() function is now updated to return a mask value regardless of input shape, and consistently return 4 values (u, v, z, mask). All call sites are updated to handle this signature.