### PR TITLE
Fixed aria_utils.project() single point outputs

### DIFF
--- a/scripts/aria_utils.py
+++ b/scripts/aria_utils.py
@@ -164,15 +164,20 @@ def project(
         )
         return u_proj[mask > 0], v_proj[mask > 0], z[mask > 0], mask
     else:
+        # normalize to scalars to handle 0d or (1,) consistently
+        u_proj_val = np.asarray(u_proj).item()
+        v_proj_val = np.asarray(v_proj).item()
+        z_val = np.asarray(z).item()
         if (
-            u_proj < 0
-            or u_proj >= frame_w - 1
-            or v_proj < 0
-            or v_proj >= frame_h - 1
-            and z > 0
+            u_proj_val < 0
+            or u_proj_val >= frame_w - 1
+            or v_proj_val < 0
+            or v_proj_val >= frame_h - 1
+            and z_val > 0
         ):
-            return None, None, None, np.array([False])
-        return u_proj, v_proj, z, np.array([True])
+            # return 1d arrays so downstream concatenations works
+            return np.array([]), np.array([]), np.array([]), np.array([False])
+        return np.array([u_proj_val]), np.array([v_proj_val]), np.array([z_val]), np.array([True])
 
 
 def read_frames_from_metadata(transforms_json: str = "transforms.json"):

--- a/scripts/extract_aria_vrs.py
+++ b/scripts/extract_aria_vrs.py
@@ -970,10 +970,10 @@ def create_visible_depth_map(
 
             u, v, z, _ = project(pt3d[:, None], w2c, calibK, frame_h, frame_w)
 
-            if u is not None:
-                frame_pts3d["u"].append(u[0])
-                frame_pts3d["v"].append(v[0])
-                frame_pts3d["z"].append(z[0])
+            if u.size > 0:
+                frame_pts3d["u"].append(float(u[0]))
+                frame_pts3d["v"].append(float(v[0]))
+                frame_pts3d["z"].append(float(z[0]))
                 frame_pts3d["inverseDistanceStd"].append(
                     points3d[uid].inverse_distance_std
                 )


### PR DESCRIPTION
Updated project()'s single point branch output: normalize with numpy array() to avoid downstream concat dim mismatches.

Consequently, extract_aria_vrs.create_visible_depth_map() was also updated: switched u is not None → u.size > 0; cast u/v/z to float for json.dump compatibility.